### PR TITLE
Update_HelloEarthRiseMain.java

### DIFF
--- a/projavafx8/ch01/HelloEarthRise/src/projavafx/helloearthrise/ui/HelloEarthRiseMain.java
+++ b/projavafx8/ch01/HelloEarthRise/src/projavafx/helloearthrise/ui/HelloEarthRiseMain.java
@@ -111,7 +111,7 @@ public class HelloEarthRiseMain extends Application {
         scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
         scrollPane.setPannable(true);
         scrollPane.setContent(textRef);
-        
+        scrollPane.setStyle("-fx-background-color: transparent; -fx-background: transparent; ");
         
         // Combine ImageView and Group
         Group root = new Group(iv, scrollPane);


### PR DESCRIPTION
JavaFX8 requires a line of CSS styling to ensure that the scrollpane given in this example remains transparent. This fix inserts that line.